### PR TITLE
fix meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       href="https://img.icons8.com/color/344/calculator--v1.png"
     />
     <script src="index.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <meta property="og:title" content="Hitman Milliseconds Time Calculator" />
     <meta property="og:description" content="" />
     <meta

--- a/index.html
+++ b/index.html
@@ -1,6 +1,9 @@
-<!-- Do a Find and Replace for "index" vs "over5" for findTotal() and initPage() function inputs.
-  That's the only difference between index.html and over5.html.
-  NOTE: For find and replace, put ' ' (and not " ") around the arg names, to avoid changing the above comment by accident.
+<!-- 
+  Do a Find and Replace for `index` vs `over5` for findTotal() and initPage() function inputs.
+    NOTE: For the above Find and Replace, put ' ' (and not ` `) around the arg names, to avoid accidental comment changes.
+
+  Also do a Find and Replace for For `Runs of Under 5 Minutes` and `For Runs of 5 to 15 Minutes` (og:description meta tag).
+    NOTE: For the above Find and Replace. put " " (and not ` `) around the arg names, to avoid accidental comment changes.  
 -->
 
 <!DOCTYPE html>
@@ -12,9 +15,8 @@
       href="https://img.icons8.com/color/344/calculator--v1.png"
     />
     <script src="index.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <meta property="og:title" content="Hitman Milliseconds Time Calculator" />
-    <meta property="og:description" content="" />
+    <meta property="og:description" content="For Runs of Under 5 Minutes" />
     <meta
       property="og:image"
       content="https://img.icons8.com/color/344/calculator--v1.png"

--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ function initPage(pageFlag) {
     : "Calculator for Runs of 5 to 15 Minutes";
 
   // Initialize any differing HTML elements for "Under 5 (index)" vs "5 to 15 Minutes (over5)" pages
-  $('meta[property=og\\:description]').attr('content', metaDescription);
+  $("meta[property=og\\:description]").attr("content", metaDescription);
   document.title = titleHeaderText;
   document.getElementById("titleHeader").textContent = titleHeaderText;
   document.getElementById("otherPage").text = otherPageLinkText;

--- a/index.js
+++ b/index.js
@@ -234,9 +234,6 @@ function initPage(pageFlag) {
   }
   const currentPage = over5Flag ? "over5" : "index";
   const otherPage = over5Flag ? "index" : "over5";
-  const metaDescription = over5Flag
-    ? "For Runs of 5 to 15 Minutes"
-    : "For Runs Under 5 Minutes";
   const titleHeaderText = over5Flag
     ? "HITMAN Milliseconds Time Calculator (5 to 15 Minutes)"
     : "HITMAN Milliseconds Time Calculator (Under 5 Minutes)";
@@ -245,7 +242,6 @@ function initPage(pageFlag) {
     : "Calculator for Runs of 5 to 15 Minutes";
 
   // Initialize any differing HTML elements for "Under 5 (index)" vs "5 to 15 Minutes (over5)" pages
-  $("meta[property=og\\:description]").attr("content", metaDescription);
   document.title = titleHeaderText;
   document.getElementById("titleHeader").textContent = titleHeaderText;
   document.getElementById("otherPage").text = otherPageLinkText;

--- a/index.js
+++ b/index.js
@@ -245,9 +245,7 @@ function initPage(pageFlag) {
     : "Calculator for Runs of 5 to 15 Minutes";
 
   // Initialize any differing HTML elements for "Under 5 (index)" vs "5 to 15 Minutes (over5)" pages
-  document
-    .querySelector('meta[property="og:description"]')
-    .setAttribute("content", metaDescription);
+  $('meta[property=og\\:description]').attr('content', metaDescription);
   document.title = titleHeaderText;
   document.getElementById("titleHeader").textContent = titleHeaderText;
   document.getElementById("otherPage").text = otherPageLinkText;

--- a/over5.html
+++ b/over5.html
@@ -12,6 +12,7 @@
       href="https://img.icons8.com/color/344/calculator--v1.png"
     />
     <script src="index.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <meta property="og:title" content="Hitman Milliseconds Time Calculator" />
     <meta property="og:description" content="" />
     <meta

--- a/over5.html
+++ b/over5.html
@@ -1,6 +1,9 @@
-<!-- Do a Find and Replace for "index" vs "over5" for findTotal() and initPage() function inputs.
-  That's the only difference between index.html and over5.html.
-  NOTE: For find and replace, put ' ' (and not " ") around the arg names, to avoid changing the above comment by accident.
+<!-- 
+  Do a Find and Replace for `index` vs `over5` for findTotal() and initPage() function inputs.
+    NOTE: For the above Find and Replace, put ' ' (and not ` `) around the arg names, to avoid accidental comment changes.
+
+  Also do a Find and Replace for For `For Runs of Under 5 Minutes` and `For Runs of 5 to 15 Minutes` (og:description meta tag).
+    NOTE: For the above Find and Replace. put " " (and not ` `) around the arg names, to avoid accidental comment changes.  
 -->
 
 <!DOCTYPE html>
@@ -12,9 +15,8 @@
       href="https://img.icons8.com/color/344/calculator--v1.png"
     />
     <script src="index.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <meta property="og:title" content="Hitman Milliseconds Time Calculator" />
-    <meta property="og:description" content="" />
+    <meta property="og:description" content="For Runs of 5 to 15 Minutes" />
     <meta
       property="og:image"
       content="https://img.icons8.com/color/344/calculator--v1.png"


### PR DESCRIPTION
For some reason the og:meta description doesn't update for discord embeds (when using a script that is called `onLoad()`), which was mostly what I was using to test if this property worked:
![image](https://github.com/solderq35/time-calc-under-5/assets/82061589/57badf72-b63a-47a2-bc8a-a746e131bbaf)

Decided to just go with hardcoding the meta description, and updated the comment at the top of the HTML files to warn about this.
